### PR TITLE
Implement owner functionality for external tools

### DIFF
--- a/dv-marketplace/src/components/UI/Navigation/NavOptions.tsx
+++ b/dv-marketplace/src/components/UI/Navigation/NavOptions.tsx
@@ -14,12 +14,14 @@ const NavOptions = () => {
             <Dropdown.Toggle variant="{theme}" id="dropdown-basic">
                 {userContext.user.username}
             </Dropdown.Toggle>
-            <Dropdown.Menu>
-                <Dropdown.Item >            
-                    {/* <Link to="/install" className="nav-link">Install</Link> */}
-                    <Link to="/addExtTool" className="nav-link">Add External Tool</Link>    
-                </Dropdown.Item>
-            </Dropdown.Menu>
+            <Dropdown.Menu>            
+                {userContext.user.roles.includes("EDITOR") && (
+                    <Dropdown.Item >            
+                        {/* <Link to="/install" className="nav-link">Install</Link> */}
+                        <Link to="/addExtTool" className="nav-link">Add External Tool</Link>    
+                    </Dropdown.Item>
+                )}
+                </Dropdown.Menu>
             </Dropdown>
         )}                    
         </>

--- a/dv-marketplace/src/components/UI/Navigation/NavOptions.tsx
+++ b/dv-marketplace/src/components/UI/Navigation/NavOptions.tsx
@@ -12,7 +12,7 @@ const NavOptions = () => {
         {userContext.user && (
             <Dropdown className="theme-switcher">
             <Dropdown.Toggle variant="{theme}" id="dropdown-basic">
-                Admin
+                {userContext.user.username}
             </Dropdown.Toggle>
             <Dropdown.Menu>
                 <Dropdown.Item >            

--- a/dv-marketplace/src/components/pages/MarketplaceHome/MarketplaceHome.tsx
+++ b/dv-marketplace/src/components/pages/MarketplaceHome/MarketplaceHome.tsx
@@ -1,25 +1,51 @@
+import { useState } from "react";
 import CardDeck from "../../UI/CardDeck";
 import { MarketplaceCard } from "../../UI/MarketplaceCard";
 import DvPromoCarrousel from "./DvPromoCarrousel";
 import useMarketplaceHome from "./useMarketplaceHome";
 function MarketplaceHome () {
 
+    const [onlyMine, setOnlyMine] = useState(false);
     const {
-        tools
-    } = useMarketplaceHome();
-    
+        tools, userContext
+    } = useMarketplaceHome(onlyMine);
+    const isLoggedIn = !!userContext.user;
+
     return (<>
         <DvPromoCarrousel />
-        <CardDeck>
-            {tools.map(tool => (
-                <MarketplaceCard key={tool.id}
-                   header={tool.name}
-                   imageId={tool?.images[0]?.storedResourceId}
-                   text={tool.description}
-                   link={`/view/${tool.id}`}
-                   />
-            ))}
-        </CardDeck>
+
+        <div style={{
+            display: 'flex', 
+            flexDirection: 'row', 
+            flexWrap: 'wrap', 
+            justifyContent: 'center',
+            marginTop: '10px',
+            minHeight: '25px',  // Space for checkbox
+            }}>
+
+                {isLoggedIn && (                
+                    <label>
+                        <input
+                            type="checkbox"
+                            checked={onlyMine}
+                            onChange={(e) => setOnlyMine(e.target.checked)}
+                        />
+                        &nbsp;Show only my tools
+                    </label>
+                )}
+            </div>
+
+            <CardDeck>
+                {tools.map(tool => (
+                    <MarketplaceCard key={tool.id}
+                    header={tool.name}
+                    imageId={tool?.images[0]?.storedResourceId}
+                    text={tool.description}
+                    link={`/view/${tool.id}`}
+                    />
+                ))}
+            </CardDeck>
+
         </>
     );
 }

--- a/dv-marketplace/src/components/pages/MarketplaceHome/useMarketplaceHome.tsx
+++ b/dv-marketplace/src/components/pages/MarketplaceHome/useMarketplaceHome.tsx
@@ -1,29 +1,39 @@
-import { useEffect, useState } from "react";
+import { useContext, useEffect, useState } from "react";
 import type { ExternalTool } from '../../../types/MarketplaceTypes';
 import axios from "axios";
 import useMarketplaceApiRepo from "../../../repositories/useMarketplaceApiRepo";
+import { UserContext } from "../../context/UserContextProvider";
 
-export default function useMarketplaceHome() {
+export default function useMarketplaceHome(onlyMine = false) {
 
     const [tools, setTools] = useState<ExternalTool[]>([]);
     const {BASE_URL} = useMarketplaceApiRepo();
+    const userContext = useContext(UserContext);
+
 
     useEffect(() => {
         const fetchTools = async () => {
             try {
-                const response = await axios.get(`${BASE_URL}/api/tools`);
+                const url = onlyMine && userContext.user?.id
+                ? `${BASE_URL}/api/tools/owner/${userContext.user.id}`
+                : `${BASE_URL}/api/tools`; // fallback: all tools
+
+                const response = await axios.get(url);
                 setTools(response.data);
             } catch (error) {
                 console.error('Error fetching tools:', error);
             }
         };
 
+
+
         fetchTools();
-    }, [BASE_URL]);
+    }, [BASE_URL,userContext.user?.id,onlyMine]);
 
 
     return {
-        tools
+        tools,
+        userContext
     };
 
 }

--- a/dv-marketplace/src/components/pages/ViewExternalTool.tsx
+++ b/dv-marketplace/src/components/pages/ViewExternalTool.tsx
@@ -42,11 +42,12 @@ const ViewExternalTool = () => {
 
         <Alert variant='light'>
         <div className='container '>
-            
             <div className='row'>
                 <h1 className='col-6'>{tool?.name}:</h1>
                 <div className='col-6 d-flex justify-content-end align-items-center'>
-                    {userContext.user &&
+                    {userContext.user && 
+                    ( userContext.user.roles.includes("ADMIN") ||
+                    (userContext.user.roles.includes("EDITOR")  && tool?.owner.id == userContext.user.id))  &&
                         <Link to ={`/edit/${id}`} className="btn btn-secondary bi-pen" > Edit</Link>
                     }
                 </div>

--- a/src/main/java/org/dataverse/marketplace/controller/api/ExternalToolVersionController.java
+++ b/src/main/java/org/dataverse/marketplace/controller/api/ExternalToolVersionController.java
@@ -46,7 +46,8 @@ public class ExternalToolVersionController {
     /**
      * Method to update a specific external tool version
      */
-    @PreAuthorize(ApplicationRoles.ADMIN_ROLE)
+    @PreAuthorize(ApplicationRoles.ADMIN_ROLE 
+      + " or (" + ApplicationRoles.EDITOR_ROLE + " and @externalToolService.getToolById(#toolId).getOwner().getId() == authentication.getPrincipal().getId)")
     @CacheEvict(value = "externalTools", allEntries = true)
     @PutMapping("/{toolId}/versions/{versionId}")
     @ExternalToolVersionsAPIDocs.UpdateVersionByIdDoc
@@ -71,7 +72,8 @@ public class ExternalToolVersionController {
     /**
      * Method to delete a specific external tool version
      */
-    @PreAuthorize(ApplicationRoles.ADMIN_ROLE)
+    @PreAuthorize(ApplicationRoles.ADMIN_ROLE 
+      + " or (" + ApplicationRoles.EDITOR_ROLE + " and @externalToolService.getToolById(#toolId).getOwner().getId() == authentication.getPrincipal().getId)")
     @CacheEvict(value = "externalTools", allEntries = true)
     @DeleteMapping("/{toolId}/versions/{versionId}")
     @ExternalToolVersionsAPIDocs.DeleteExternalToolVersionByIdDoc
@@ -105,7 +107,8 @@ public class ExternalToolVersionController {
     /**
      * Method to add a new version to an existing external tool
      */
-    @PreAuthorize(ApplicationRoles.ADMIN_ROLE)
+    @PreAuthorize(ApplicationRoles.ADMIN_ROLE 
+      + " or (" + ApplicationRoles.EDITOR_ROLE + " and @externalToolService.getToolById(#toolId).getOwner().getId() == authentication.getPrincipal().getId)")
     @CacheEvict(value = "externalTools", allEntries = true)
     @PostMapping(path = "/{toolId}/versions", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     @ExternalToolVersionsAPIDocs.AddExternalToolVersionDoc
@@ -161,7 +164,8 @@ public class ExternalToolVersionController {
     /**
      * Method to add manifests to an existing external tool version
      */
-    @PreAuthorize(ApplicationRoles.ADMIN_ROLE)
+    @PreAuthorize(ApplicationRoles.ADMIN_ROLE 
+      + " or (" + ApplicationRoles.EDITOR_ROLE + " and @externalToolService.getToolById(#toolId).getOwner().getId() == authentication.getPrincipal().getId)")
     @CacheEvict(value = "externalTools", allEntries = true)    
     @PostMapping(path = "/{toolId}/versions/{versionId}/manifests", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     @ExternalToolVersionsAPIDocs.AddVersionManifestDoc
@@ -210,7 +214,8 @@ public class ExternalToolVersionController {
     /**
      * Method to delete a specific manifest of an external tool version
      */
-    @PreAuthorize(ApplicationRoles.ADMIN_ROLE)
+    @PreAuthorize(ApplicationRoles.ADMIN_ROLE 
+      + " or (" + ApplicationRoles.EDITOR_ROLE + " and @externalToolService.getToolById(#toolId).getOwner().getId() == authentication.getPrincipal().getId)")
     @CacheEvict(value = "externalTools", allEntries = true)
     @ExternalToolVersionsAPIDocs.DeleteVersionManifestDoc
     @DeleteMapping("/{toolId}/versions/{versionId}/manifests/{manifestId}")

--- a/src/main/java/org/dataverse/marketplace/model/MarketplaceItem.java
+++ b/src/main/java/org/dataverse/marketplace/model/MarketplaceItem.java
@@ -33,6 +33,10 @@ public class MarketplaceItem implements Serializable{
     )
     private Set<ItemTag> tags;
 
+    @ManyToOne (optional = false)
+    @JoinColumn(name = "owner_id", nullable = false) 
+    User owner;    
+
     /* Getters & Setters */
 
     public Integer getId() {
@@ -75,6 +79,12 @@ public class MarketplaceItem implements Serializable{
         this.tags = tags;
     }
 
+    public User getOwner() {
+        return owner;
+    }
     
-
+    public void setOwner(User owner) {
+        this.owner = owner;
+    }    
+    
 }

--- a/src/main/java/org/dataverse/marketplace/model/User.java
+++ b/src/main/java/org/dataverse/marketplace/model/User.java
@@ -1,6 +1,7 @@
 package org.dataverse.marketplace.model;
 
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 import jakarta.persistence.*;
@@ -31,8 +32,12 @@ public class User {
     @JoinTable(name = "user_roles", joinColumns = @jakarta.persistence.JoinColumn(name = "user_id"), inverseJoinColumns = @jakarta.persistence.JoinColumn(name = "role_id"))
     private Set<Role> roles = new HashSet<>();
     
+    @OneToMany(mappedBy = "owner")
+    private List<MarketplaceItem> marketplaceItems;    
 
     public User() {
+
+
     }
 
     public User(String username, String email, String password) {
@@ -81,6 +86,15 @@ public class User {
 
     public void setRoles(Set<Role> roles) {
         this.roles = roles;
+    }
+
+
+    public List<MarketplaceItem> getMarketplaceItems() {
+        return this.marketplaceItems;
+    }
+
+    public void setMarketplaceItems(List<MarketplaceItem> marketplaceItems) {
+        this.marketplaceItems = marketplaceItems;
     }
 
 }

--- a/src/main/java/org/dataverse/marketplace/openapi/annotations/ExternalToolsAPIDocs.java
+++ b/src/main/java/org/dataverse/marketplace/openapi/annotations/ExternalToolsAPIDocs.java
@@ -29,247 +29,116 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 
 public @interface ExternalToolsAPIDocs {
 
-    @Target({ElementType.METHOD})    
+    @Target({ ElementType.METHOD })
     @Retention(RetentionPolicy.RUNTIME)
     @Tag(name = "External Tools")
     @ApiResponses(value = {
-        @ApiResponse(responseCode = "200", 
-                        description = "External tools successfully retrieved",
-                        content = @Content(mediaType = "application/json",
-                        schema = @Schema(implementation = ExternalToolDTO[].class),
-                        examples = @ExampleObject(ExternalToolSamples.EXTERNAL_TOOLS_LIST_SAMPLE))),    
-        @ApiResponse(responseCode = "400", 
-                        description = "Bad request on External tools list retrieval",
-                        content = @Content(mediaType = "application/json",
-                        schema = @Schema(implementation = ServerMessageResponse.class),
-                        examples = @ExampleObject(GenericBusinessSamples.SERVER_MESSAGE_RESPONSE))),
-        @ApiResponse(responseCode = "401", 
-                        description = "Bad credentials on External tools list retrieval",
-                        content = @Content(mediaType = "application/json",
-                        schema = @Schema(implementation = ServerMessageResponse.class),
-                        examples = @ExampleObject(GenericBusinessSamples.SERVER_MESSAGE_RESPONSE))),
-        @ApiResponse(responseCode = "500", 
-                        description = "Internal Server Error during External tools list retrieval",
-                        content = @Content(mediaType = "application/json",
-                        schema = @Schema(implementation = ServerMessageResponse.class),
-                        examples = @ExampleObject(GenericBusinessSamples.SERVER_MESSAGE_RESPONSE)))
+            @ApiResponse(responseCode = "200", description = "External tools successfully retrieved", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ExternalToolDTO[].class), examples = @ExampleObject(ExternalToolSamples.EXTERNAL_TOOLS_LIST_SAMPLE))),
+            @ApiResponse(responseCode = "400", description = "Bad request on External tools list retrieval", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ServerMessageResponse.class), examples = @ExampleObject(GenericBusinessSamples.SERVER_MESSAGE_RESPONSE))),
+            @ApiResponse(responseCode = "401", description = "Bad credentials on External tools list retrieval", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ServerMessageResponse.class), examples = @ExampleObject(GenericBusinessSamples.SERVER_MESSAGE_RESPONSE))),
+            @ApiResponse(responseCode = "500", description = "Internal Server Error during External tools list retrieval", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ServerMessageResponse.class), examples = @ExampleObject(GenericBusinessSamples.SERVER_MESSAGE_RESPONSE)))
     })
-    @Operation(summary = "Returns a list of all external tools",
-                description = "This endpoint will return a list of all external tools available in the marketplace.")
-    public @interface ExternalToolsListDoc{}
+    @Operation(summary = "Returns a list of all external tools", description = "This endpoint will return a list of all external tools available in the marketplace.")
+    public @interface ExternalToolsListDoc {
+    }
 
-    @Target({ElementType.METHOD})    
+    @Target({ ElementType.METHOD })
     @Retention(RetentionPolicy.RUNTIME)
     @Tag(name = "External Tools")
     @ApiResponses(value = {
-        @ApiResponse(responseCode = "200", 
-                        description = "Add new external tool",
-                        content = @Content(mediaType = "application/json",
-                        schema = @Schema(implementation = ExternalToolDTO.class),
-                        examples = @ExampleObject(ExternalToolSamples.EXTERNAL_TOOL_SINGLE_SAMPLE))),    
-        @ApiResponse(responseCode = "400", 
-                        description = "Bad request when adding a new external tool",
-                        content = @Content(mediaType = "application/json",
-                        schema = @Schema(implementation = ServerMessageResponse.class),
-                        examples = @ExampleObject(GenericBusinessSamples.SERVER_MESSAGE_RESPONSE))),
-        @ApiResponse(responseCode = "401", 
-                        description = "Bad credentials when adding a new external tool",
-                        content = @Content(mediaType = "application/json",
-                        schema = @Schema(implementation = ServerMessageResponse.class),
-                        examples = @ExampleObject(GenericBusinessSamples.SERVER_MESSAGE_RESPONSE))),
-        @ApiResponse(responseCode = "500", 
-                        description = "Internal Server Error when adding a new external tool",
-                        content = @Content(mediaType = "application/json",
-                        schema = @Schema(implementation = ServerMessageResponse.class),
-                        examples = @ExampleObject(GenericBusinessSamples.SERVER_MESSAGE_RESPONSE)))
+            @ApiResponse(responseCode = "200", description = "Add new external tool", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ExternalToolDTO.class), examples = @ExampleObject(ExternalToolSamples.EXTERNAL_TOOL_SINGLE_SAMPLE))),
+            @ApiResponse(responseCode = "400", description = "Bad request when adding a new external tool", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ServerMessageResponse.class), examples = @ExampleObject(GenericBusinessSamples.SERVER_MESSAGE_RESPONSE))),
+            @ApiResponse(responseCode = "401", description = "Bad credentials when adding a new external tool", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ServerMessageResponse.class), examples = @ExampleObject(GenericBusinessSamples.SERVER_MESSAGE_RESPONSE))),
+            @ApiResponse(responseCode = "500", description = "Internal Server Error when adding a new external tool", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ServerMessageResponse.class), examples = @ExampleObject(GenericBusinessSamples.SERVER_MESSAGE_RESPONSE)))
     })
-    @Operation(summary = "Adds a new external tool",
-                description = "This endpoint will add a new external tool to the marketplace.")
-    @RequestBody(description = "The external tool creation request", 
-                required = true, 
-                content = @Content(mediaType = "multipart/form-data",
-                schema = @Schema(implementation = AddToolRequest.class),
-                examples = @ExampleObject(ExternalToolSamples.EXTERNAL_TOOL_MULTIPART_FORM_SAMPLE)))
-    public @interface AddExternalToolsRequestDoc{}
+    @Operation(summary = "Adds a new external tool", description = "This endpoint will add a new external tool to the marketplace.")
+    @RequestBody(description = "The external tool creation request", required = true, content = @Content(mediaType = "multipart/form-data", schema = @Schema(implementation = AddToolRequest.class), examples = @ExampleObject(ExternalToolSamples.EXTERNAL_TOOL_MULTIPART_FORM_SAMPLE)))
+    public @interface AddExternalToolsRequestDoc {
+    }
 
-    @Target({ElementType.METHOD})    
+    @Target({ ElementType.METHOD })
     @Retention(RetentionPolicy.RUNTIME)
     @Tag(name = "External Tools")
     @ApiResponses(value = {
-        @ApiResponse(responseCode = "200", 
-                        description = "External Tool successfully retrieved",
-                        content = @Content(mediaType = "application/json",
-                        schema = @Schema(implementation = UserDTO.class),
-                        examples = @ExampleObject(AuthAPISamples.USER))),
-        @ApiResponse(responseCode = "400", 
-                        description = "Bad request on External Tool retrieval",
-                        content = @Content(mediaType = "application/json",
-                        schema = @Schema(implementation = ServerMessageResponse.class),
-                        examples = @ExampleObject(GenericBusinessSamples.SERVER_MESSAGE_RESPONSE))),
-        @ApiResponse(responseCode = "401", 
-                        description = "Access Denied for External Tool retrieval",
-                        content = @Content(mediaType = "application/json",
-                        schema = @Schema(implementation = ServerMessageResponse.class),
-                        examples = @ExampleObject(GenericBusinessSamples.SERVER_MESSAGE_RESPONSE))),
-        @ApiResponse(responseCode = "500", 
-                        description = "Internal Server Error during External Tool retrieval",
-                        content = @Content(mediaType = "application/json",
-                        schema = @Schema(implementation = ServerMessageResponse.class),
-                        examples = @ExampleObject(GenericBusinessSamples.SERVER_MESSAGE_RESPONSE)))                        
+            @ApiResponse(responseCode = "200", description = "External Tool successfully retrieved", content = @Content(mediaType = "application/json", schema = @Schema(implementation = UserDTO.class), examples = @ExampleObject(AuthAPISamples.USER))),
+            @ApiResponse(responseCode = "400", description = "Bad request on External Tool retrieval", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ServerMessageResponse.class), examples = @ExampleObject(GenericBusinessSamples.SERVER_MESSAGE_RESPONSE))),
+            @ApiResponse(responseCode = "401", description = "Access Denied for External Tool retrieval", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ServerMessageResponse.class), examples = @ExampleObject(GenericBusinessSamples.SERVER_MESSAGE_RESPONSE))),
+            @ApiResponse(responseCode = "500", description = "Internal Server Error during External Tool retrieval", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ServerMessageResponse.class), examples = @ExampleObject(GenericBusinessSamples.SERVER_MESSAGE_RESPONSE)))
     })
-    @Operation(summary = "Retrieves the information from the specified external tool.",
-                description = "This endpoint retrieves the information from the specified external tool by id.")    
-    @Parameter(name = "toolId",
-                description = "The id of the external tool to be retrieved",
-                required = true,
-                in = ParameterIn.PATH,
-                schema = @Schema(type = "integer"))
-    public @interface GetExternalToolByIdDoc{}
+    @Operation(summary = "Retrieves the information from the specified external tool.", description = "This endpoint retrieves the information from the specified external tool by id.")
+    @Parameter(name = "toolId", description = "The id of the external tool to be retrieved", required = true, in = ParameterIn.PATH, schema = @Schema(type = "integer"))
+    public @interface GetExternalToolByIdDoc {
+    }
 
-    @Target({ElementType.METHOD})    
+    @Target({ ElementType.METHOD })
     @Retention(RetentionPolicy.RUNTIME)
     @Tag(name = "External Tools Images")
     @ApiResponses(value = {
-        @ApiResponse(responseCode = "200", 
-                        description = "External Tool Image Resource-IDs list successfully retrieved",
-                        content = @Content(mediaType = "application/json",
-                        schema = @Schema(implementation = Long[].class),
-                        examples = @ExampleObject("[1, 2, 3]"))),
-        @ApiResponse(responseCode = "400", 
-                        description = "Bad request on External Tool Image Resource-IDs list successfully retrieved",
-                        content = @Content(mediaType = "application/json",
-                        schema = @Schema(implementation = ServerMessageResponse.class),
-                        examples = @ExampleObject(GenericBusinessSamples.SERVER_MESSAGE_RESPONSE))),
-        @ApiResponse(responseCode = "401", 
-                        description = "Access Denied for External Tool Image Resource-IDs list successfully retrieved",
-                        content = @Content(mediaType = "application/json",
-                        schema = @Schema(implementation = ServerMessageResponse.class),
-                        examples = @ExampleObject(GenericBusinessSamples.SERVER_MESSAGE_RESPONSE))),
-        @ApiResponse(responseCode = "500", 
-                        description = "Internal Server Error during External Tool Image Resource-IDs list successfully retrieved",
-                        content = @Content(mediaType = "application/json",
-                        schema = @Schema(implementation = ServerMessageResponse.class),
-                        examples = @ExampleObject(GenericBusinessSamples.SERVER_MESSAGE_RESPONSE)))                        
+            @ApiResponse(responseCode = "200", description = "External Tool Image Resource-IDs list successfully retrieved", content = @Content(mediaType = "application/json", schema = @Schema(implementation = Long[].class), examples = @ExampleObject("[1, 2, 3]"))),
+            @ApiResponse(responseCode = "400", description = "Bad request on External Tool Image Resource-IDs list successfully retrieved", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ServerMessageResponse.class), examples = @ExampleObject(GenericBusinessSamples.SERVER_MESSAGE_RESPONSE))),
+            @ApiResponse(responseCode = "401", description = "Access Denied for External Tool Image Resource-IDs list successfully retrieved", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ServerMessageResponse.class), examples = @ExampleObject(GenericBusinessSamples.SERVER_MESSAGE_RESPONSE))),
+            @ApiResponse(responseCode = "500", description = "Internal Server Error during External Tool Image Resource-IDs list successfully retrieved", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ServerMessageResponse.class), examples = @ExampleObject(GenericBusinessSamples.SERVER_MESSAGE_RESPONSE)))
     })
-    @Operation(summary = "Retrieves the list of image resource-ids from the specified external tool.",
-                description = "This endpoint retrieves the list of image resource-ids from the specified external tool by id.")    
-    @Parameter(name = "toolId",
-                description = "The id of the external tool to retrieve the image resource-ids list",
-                required = true,
-                in = ParameterIn.PATH,
-                schema = @Schema(type = "integer"))    
-    public @interface GetToolImagesDoc{}
+    @Operation(summary = "Retrieves the list of image resource-ids from the specified external tool.", description = "This endpoint retrieves the list of image resource-ids from the specified external tool by id.")
+    @Parameter(name = "toolId", description = "The id of the external tool to retrieve the image resource-ids list", required = true, in = ParameterIn.PATH, schema = @Schema(type = "integer"))
+    public @interface GetToolImagesDoc {
+    }
 
-    @Target({ElementType.METHOD})    
+    @Target({ ElementType.METHOD })
     @Retention(RetentionPolicy.RUNTIME)
     @Tag(name = "External Tools Images")
     @ApiResponses(value = {
-        @ApiResponse(responseCode = "200", 
-                        description = "External Tool Image successfully added",
-                        content = @Content(mediaType = "application/json",
-                        schema = @Schema(implementation = MarketplaceItemImageDTO.class),
-                        examples = @ExampleObject(ExternalToolSamples.EXTERNAL_TOOL_IMAGE_SAMPLE))),
-        @ApiResponse(responseCode = "400", 
-                        description = "Bad request on External Tool Image successfully added",
-                        content = @Content(mediaType = "application/json",
-                        schema = @Schema(implementation = ServerMessageResponse.class),
-                        examples = @ExampleObject(GenericBusinessSamples.SERVER_MESSAGE_RESPONSE))),
-        @ApiResponse(responseCode = "401", 
-                        description = "Access Denied for External Tool Image successfully added",
-                        content = @Content(mediaType = "application/json",
-                        schema = @Schema(implementation = ServerMessageResponse.class),
-                        examples = @ExampleObject(GenericBusinessSamples.SERVER_MESSAGE_RESPONSE))),
-        @ApiResponse(responseCode = "500", 
-                        description = "Internal Server Error during External Tool Image successfully added",
-                        content = @Content(mediaType = "application/json",
-                        schema = @Schema(implementation = ServerMessageResponse.class),
-                        examples = @ExampleObject(GenericBusinessSamples.SERVER_MESSAGE_RESPONSE)))                        
+            @ApiResponse(responseCode = "200", description = "External Tool Image successfully added", content = @Content(mediaType = "application/json", schema = @Schema(implementation = MarketplaceItemImageDTO.class), examples = @ExampleObject(ExternalToolSamples.EXTERNAL_TOOL_IMAGE_SAMPLE))),
+            @ApiResponse(responseCode = "400", description = "Bad request on External Tool Image successfully added", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ServerMessageResponse.class), examples = @ExampleObject(GenericBusinessSamples.SERVER_MESSAGE_RESPONSE))),
+            @ApiResponse(responseCode = "401", description = "Access Denied for External Tool Image successfully added", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ServerMessageResponse.class), examples = @ExampleObject(GenericBusinessSamples.SERVER_MESSAGE_RESPONSE))),
+            @ApiResponse(responseCode = "500", description = "Internal Server Error during External Tool Image successfully added", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ServerMessageResponse.class), examples = @ExampleObject(GenericBusinessSamples.SERVER_MESSAGE_RESPONSE)))
     })
-    @Operation(summary = "Adds a new image to the specified external tool.",
-                description = "This endpoint adds a new image to the specified external tool by id.")    
-    @Parameter(name = "toolId",
-                description = "the id of the external tool to add the image",
-                required = true,
-                in = ParameterIn.PATH,
-                schema = @Schema(type = "integer")) 
-    public @interface AddToolImagesDoc{}
-    
-    @Target({ElementType.METHOD})    
+    @Operation(summary = "Adds a new image to the specified external tool.", description = "This endpoint adds a new image to the specified external tool by id.")
+    @Parameter(name = "toolId", description = "the id of the external tool to add the image", required = true, in = ParameterIn.PATH, schema = @Schema(type = "integer"))
+    public @interface AddToolImagesDoc {
+    }
+
+    @Target({ ElementType.METHOD })
     @Retention(RetentionPolicy.RUNTIME)
     @Tag(name = "External Tools Images")
     @ApiResponses(value = {
-        @ApiResponse(responseCode = "200", 
-                        description = "External Tool Image successfully deleted",
-                        content = @Content(mediaType = "application/json",
-                        schema = @Schema(implementation = ServerMessageResponse.class),
-                        examples = @ExampleObject(GenericBusinessSamples.SERVER_MESSAGE_RESPONSE))),
-        @ApiResponse(responseCode = "400", 
-                        description = "Bad request on External Tool Image successfully deleted",
-                        content = @Content(mediaType = "application/json",
-                        schema = @Schema(implementation = ServerMessageResponse.class),
-                        examples = @ExampleObject(GenericBusinessSamples.SERVER_MESSAGE_RESPONSE))),
-        @ApiResponse(responseCode = "401", 
-                        description = "Access Denied for External Tool Image successfully deleted",
-                        content = @Content(mediaType = "application/json",
-                        schema = @Schema(implementation = ServerMessageResponse.class),
-                        examples = @ExampleObject(GenericBusinessSamples.SERVER_MESSAGE_RESPONSE))),
-        @ApiResponse(responseCode = "500", 
-                        description = "Internal Server Error during External Tool Image successfully deleted",
-                        content = @Content(mediaType = "application/json",
-                        schema = @Schema(implementation = ServerMessageResponse.class),
-                        examples = @ExampleObject(GenericBusinessSamples.SERVER_MESSAGE_RESPONSE)))                        
+            @ApiResponse(responseCode = "200", description = "External Tool Image successfully deleted", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ServerMessageResponse.class), examples = @ExampleObject(GenericBusinessSamples.SERVER_MESSAGE_RESPONSE))),
+            @ApiResponse(responseCode = "400", description = "Bad request on External Tool Image successfully deleted", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ServerMessageResponse.class), examples = @ExampleObject(GenericBusinessSamples.SERVER_MESSAGE_RESPONSE))),
+            @ApiResponse(responseCode = "401", description = "Access Denied for External Tool Image successfully deleted", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ServerMessageResponse.class), examples = @ExampleObject(GenericBusinessSamples.SERVER_MESSAGE_RESPONSE))),
+            @ApiResponse(responseCode = "500", description = "Internal Server Error during External Tool Image successfully deleted", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ServerMessageResponse.class), examples = @ExampleObject(GenericBusinessSamples.SERVER_MESSAGE_RESPONSE)))
     })
-    @Operation(summary = "Deletes the specified external tool image.",
-                description = "This endpoint deletes the specified external tool image by id.")    
-    @Parameter(name = "toolId",
-                description = "The id of the external tool that contains the image to be deleted",
-                required = true,
-                in = ParameterIn.PATH,
-                schema = @Schema(type = "integer"))
-    @Parameter(name = "imageId",
-                description = "The id of the image to be deleted",
-                required = true,
-                in = ParameterIn.PATH,
-                schema = @Schema(type = "integer"))
-    public @interface DeleteToolImageDoc{}
+    @Operation(summary = "Deletes the specified external tool image.", description = "This endpoint deletes the specified external tool image by id.")
+    @Parameter(name = "toolId", description = "The id of the external tool that contains the image to be deleted", required = true, in = ParameterIn.PATH, schema = @Schema(type = "integer"))
+    @Parameter(name = "imageId", description = "The id of the image to be deleted", required = true, in = ParameterIn.PATH, schema = @Schema(type = "integer"))
+    public @interface DeleteToolImageDoc {
+    }
 
-    @Target({ElementType.METHOD})    
+    @Target({ ElementType.METHOD })
     @Retention(RetentionPolicy.RUNTIME)
     @Tag(name = "External Tools")
     @ApiResponses(value = {
-        @ApiResponse(responseCode = "200", 
-                        description = "External Tool successfully updated",
-                        content = @Content(mediaType = "application/json",
-                        schema = @Schema(implementation = ServerMessageResponse.class),
-                        examples = @ExampleObject(GenericBusinessSamples.SERVER_MESSAGE_RESPONSE))),
-        @ApiResponse(responseCode = "400", 
-                        description = "Bad request on External Tool update",
-                        content = @Content(mediaType = "application/json",
-                        schema = @Schema(implementation = ServerMessageResponse.class),
-                        examples = @ExampleObject(GenericBusinessSamples.SERVER_MESSAGE_RESPONSE))),
-        @ApiResponse(responseCode = "401", 
-                        description = "Access Denied for External Tool update",
-                        content = @Content(mediaType = "application/json",
-                        schema = @Schema(implementation = ServerMessageResponse.class),
-                        examples = @ExampleObject(GenericBusinessSamples.SERVER_MESSAGE_RESPONSE))),
-        @ApiResponse(responseCode = "500", 
-                        description = "Internal Server Error during External Tool update",
-                        content = @Content(mediaType = "application/json",
-                        schema = @Schema(implementation = ServerMessageResponse.class),
-                        examples = @ExampleObject(GenericBusinessSamples.SERVER_MESSAGE_RESPONSE)))                        
+            @ApiResponse(responseCode = "200", description = "External Tool successfully updated", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ServerMessageResponse.class), examples = @ExampleObject(GenericBusinessSamples.SERVER_MESSAGE_RESPONSE))),
+            @ApiResponse(responseCode = "400", description = "Bad request on External Tool update", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ServerMessageResponse.class), examples = @ExampleObject(GenericBusinessSamples.SERVER_MESSAGE_RESPONSE))),
+            @ApiResponse(responseCode = "401", description = "Access Denied for External Tool update", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ServerMessageResponse.class), examples = @ExampleObject(GenericBusinessSamples.SERVER_MESSAGE_RESPONSE))),
+            @ApiResponse(responseCode = "500", description = "Internal Server Error during External Tool update", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ServerMessageResponse.class), examples = @ExampleObject(GenericBusinessSamples.SERVER_MESSAGE_RESPONSE)))
     })
-    @Operation(summary = "Update the specified external tool.",
-                description = "This endpoint updates the specified external tool.")
-    @Parameter(name = "toolId",
-                description = "The id of the external tool that contains the image to be updated",
-                required = true,
-                in = ParameterIn.PATH,
-                schema = @Schema(type = "integer"))
-    @RequestBody(description = "The external tool update request", 
-                required = true, 
-                content = @Content(mediaType = "application/json",
-                schema = @Schema(implementation = UpdateToolRequest.class),
-                examples = @ExampleObject(ExternalToolSamples.UPDATE_EXTERNAL_TOOL_REQUEST)))
-    public @interface UpdateExternalToolDoc{}
+    @Operation(summary = "Update the specified external tool.", description = "This endpoint updates the specified external tool.")
+    @Parameter(name = "toolId", description = "The id of the external tool that contains the image to be updated", required = true, in = ParameterIn.PATH, schema = @Schema(type = "integer"))
+    @RequestBody(description = "The external tool update request", required = true, content = @Content(mediaType = "application/json", schema = @Schema(implementation = UpdateToolRequest.class), examples = @ExampleObject(ExternalToolSamples.UPDATE_EXTERNAL_TOOL_REQUEST)))
+    public @interface UpdateExternalToolDoc {
+    }
+
+    @Target({ ElementType.METHOD })
+    @Retention(RetentionPolicy.RUNTIME)
+    @Tag(name = "External Tools")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "External tools successfully retrieved", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ExternalToolDTO[].class), examples = @ExampleObject(ExternalToolSamples.EXTERNAL_TOOLS_LIST_SAMPLE))),
+            @ApiResponse(responseCode = "400", description = "Bad request on External tools list retrieval", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ServerMessageResponse.class), examples = @ExampleObject(GenericBusinessSamples.SERVER_MESSAGE_RESPONSE))),
+            @ApiResponse(responseCode = "401", description = "Bad credentials on External tools list retrieval", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ServerMessageResponse.class), examples = @ExampleObject(GenericBusinessSamples.SERVER_MESSAGE_RESPONSE))),
+            @ApiResponse(responseCode = "500", description = "Internal Server Error during External tools list retrieval", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ServerMessageResponse.class), examples = @ExampleObject(GenericBusinessSamples.SERVER_MESSAGE_RESPONSE)))
+    })
+    @Operation(summary = "Returns a list of all external tools by owner id", description = "This endpoint will return a list of all external tools owned by a specific user.")
+    public @interface GetExternalToolByOwnerIdDoc {
+    }
 
 }

--- a/src/main/java/org/dataverse/marketplace/payload/ExternalToolDTO.java
+++ b/src/main/java/org/dataverse/marketplace/payload/ExternalToolDTO.java
@@ -4,7 +4,9 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 import org.dataverse.marketplace.model.*;
+import org.dataverse.marketplace.openapi.samples.AuthAPISamples;
 import org.dataverse.marketplace.openapi.samples.ExternalToolVersionSamples;
+import org.dataverse.marketplace.payload.auth.UserDTO;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
@@ -33,11 +35,17 @@ public class ExternalToolDTO implements Serializable {
             example = "[1, 2, 3]")
     private List<MarketplaceItemImageDTO> images;
 
+    @Schema(description = "The owner of the external tool", 
+            implementation = UserDTO.class,
+            example = AuthAPISamples.USER)    
+    private UserDTO owner;
+
     public ExternalToolDTO() {
     }
 
     public ExternalToolDTO(ExternalTool externalTool) {
         id = externalTool.getId();
+        owner = new UserDTO(externalTool.getOwner());
         name = externalTool.getName();
         description = externalTool.getDescription();
 
@@ -98,5 +106,15 @@ public class ExternalToolDTO implements Serializable {
         this.images = images;
     }
 
+    public UserDTO getOwner() {
+        return owner;
+    }
+
+    public void setOwner(UserDTO owner) {
+        this.owner = owner;
+    }
+
+
+    
     
 }

--- a/src/main/java/org/dataverse/marketplace/payload/auth/UserDTO.java
+++ b/src/main/java/org/dataverse/marketplace/payload/auth/UserDTO.java
@@ -1,10 +1,12 @@
 package org.dataverse.marketplace.payload.auth;
 
+import java.io.Serializable;
+
 import org.dataverse.marketplace.model.User;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(name = "User", description = "A representation of the user")
-public class UserDTO {
+public class UserDTO implements Serializable{
 
     @Schema(description = "The id of the user", example = "1")
     private Long id;

--- a/src/main/java/org/dataverse/marketplace/repository/ExternalToolRepo.java
+++ b/src/main/java/org/dataverse/marketplace/repository/ExternalToolRepo.java
@@ -1,10 +1,14 @@
 package org.dataverse.marketplace.repository;
 
 
+import java.util.List;
+
 import org.dataverse.marketplace.model.ExternalTool;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 @Repository
 public interface ExternalToolRepo extends JpaRepository<ExternalTool, Integer> {
 
+    public List<ExternalTool> findByOwnerId(Integer ownerId);
+    
 }

--- a/src/main/java/org/dataverse/marketplace/security/ApplicationRoles.java
+++ b/src/main/java/org/dataverse/marketplace/security/ApplicationRoles.java
@@ -3,4 +3,5 @@ package org.dataverse.marketplace.security;
 public abstract class ApplicationRoles {
 
     public static final String ADMIN_ROLE = "hasAuthority('ADMIN')";
+    public static final String EDITOR_ROLE = "hasAuthority('EDITOR')";
 }

--- a/src/main/java/org/dataverse/marketplace/service/ExternalToolService.java
+++ b/src/main/java/org/dataverse/marketplace/service/ExternalToolService.java
@@ -46,6 +46,15 @@ public class ExternalToolService {
         return toolDTOs;
     }
 
+    public List<ExternalToolDTO> getAllToolsByOwnerId(Integer ownerId) {
+        List<ExternalTool> tools = externalToolRepo.findByOwnerId(ownerId);
+        ArrayList<ExternalToolDTO> toolDTOs = new ArrayList<>();
+        for (ExternalTool tool : tools) {
+            toolDTOs.add(new ExternalToolDTO(tool));
+        }
+        return toolDTOs;
+    }    
+
     public ExternalTool getToolById(Integer toolId) {
         return externalToolRepo.findById(toolId).orElse(null);
     }
@@ -60,9 +69,10 @@ public class ExternalToolService {
 
     @CacheEvict(value = "externalTools", allEntries = true)
     @Transactional
-    public ExternalToolDTO addTool(AddToolRequest addToolRequest) throws IOException {
+    public ExternalToolDTO addTool(AddToolRequest addToolRequest, User owner) throws IOException {
 
         ExternalTool newTool = new ExternalTool();
+        newTool.setOwner(owner);
         newTool.setName(addToolRequest.getName());
         newTool.setDescription(addToolRequest.getDescription());
         externalToolRepo.save(newTool);
@@ -128,5 +138,6 @@ public class ExternalToolService {
     public void deleteToolImage(MarketplaceItemImage image) {
         marketplaceItemImageRepo.delete(image);
     }
+    
 
 }

--- a/src/main/resources/db/migration/V1_0_2__user_changes.sql
+++ b/src/main/resources/db/migration/V1_0_2__user_changes.sql
@@ -5,3 +5,6 @@ ADD COLUMN owner_id integer NOT NULL;
 -- Add the foreign key constraint
 ALTER TABLE marketplace_item
 ADD CONSTRAINT fk_marketplace_item_owner FOREIGN KEY (owner_id) REFERENCES "users"(id);
+
+-- add new role
+insert into roles (id, role_name) values (nextval('role_id_seq'), 'EDITOR');

--- a/src/main/resources/db/migration/V1_0_2__user_changes.sql
+++ b/src/main/resources/db/migration/V1_0_2__user_changes.sql
@@ -1,0 +1,7 @@
+-- Add the owner_id column to marketplace_item
+ALTER TABLE marketplace_item
+ADD COLUMN owner_id integer NOT NULL;
+
+-- Add the foreign key constraint
+ALTER TABLE marketplace_item
+ADD CONSTRAINT fk_marketplace_item_owner FOREIGN KEY (owner_id) REFERENCES "users"(id);

--- a/src/main/resources/db/migration/V1_0_2_user_changes.sql
+++ b/src/main/resources/db/migration/V1_0_2_user_changes.sql
@@ -1,0 +1,4 @@
+-- Add the owner_id column to marketplace_item
+ALTER TABLE marketplace_item
+ADD COLUMN owner_id integer NOT NULL;
+ADD CONSTRAINT fk_marketplace_item_owner FOREIGN KEY (owner_id) REFERENCES "user"(id);

--- a/src/main/resources/db/migration/V1_0_2_user_changes.sql
+++ b/src/main/resources/db/migration/V1_0_2_user_changes.sql
@@ -1,4 +1,0 @@
--- Add the owner_id column to marketplace_item
-ALTER TABLE marketplace_item
-ADD COLUMN owner_id integer NOT NULL;
-ADD CONSTRAINT fk_marketplace_item_owner FOREIGN KEY (owner_id) REFERENCES "user"(id);

--- a/src/test/java/org/dataverse/marketplace/ExternalToolsTest.java
+++ b/src/test/java/org/dataverse/marketplace/ExternalToolsTest.java
@@ -32,239 +32,252 @@ import org.springframework.web.client.RestTemplate;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 public class ExternalToolsTest {
 
-    @LocalServerPort
-    private int port;
+        @LocalServerPort
+        private int port;
 
-    private RestTemplate restTemplate = new RestTemplate();
-  
+        private RestTemplate restTemplate = new RestTemplate();
 
-    @Test
-    public void TestExternalTools() throws InterruptedException {
+        @Test
+        public void TestExternalTools() throws InterruptedException {   
 
-        String serverUrl = "http://localhost:" + port + "/api/";
-        String toolsUrl = serverUrl + "/tools/";
+                String serverUrl = "http://localhost:" + port + "/api/";
+                String toolsUrl = serverUrl + "/tools/";
 
-        JwtResponse adminLogin = LoginAndAuthTest.testLogin("admin", "admin", restTemplate, serverUrl);
-        assertNotNull(adminLogin);
+                JwtResponse adminLogin = LoginAndAuthTest.testLogin("admin", "admin", restTemplate, serverUrl);
+                assertNotNull(adminLogin);
 
-        // Headers for admin
-        HttpHeaders adminHeaders = new HttpHeaders();
-        adminHeaders.setBearerAuth(adminLogin.getAccessToken());
+                // Headers for admin
+                HttpHeaders adminHeaders = new HttpHeaders();
+                adminHeaders.setBearerAuth(adminLogin.getAccessToken());
 
-        // Unauthorized user
-        HttpHeaders userHeaders = new HttpHeaders();
+                // Unauthorized user
+                HttpHeaders userHeaders = new HttpHeaders();
 
-        // Get tools test
-        ResponseEntity<ExternalToolDTO[]> getToolsResponse = restTemplate.getForEntity(serverUrl + "/tools",
-                ExternalToolDTO[].class);
-        assertEquals(getToolsResponse.getStatusCode(), HttpStatus.OK);
+                // Get tools test
+                ResponseEntity<ExternalToolDTO[]> getToolsResponse = restTemplate.getForEntity(serverUrl + "/tools",
+                                ExternalToolDTO[].class);
+                assertEquals(getToolsResponse.getStatusCode(), HttpStatus.OK);
 
-        // Post tools test
-        File jsonData = new File("src/test/resources/askthedata.json");
-        assertEquals(jsonData.exists(), true);
+                // Post tools test
+                File jsonData = new File("src/test/resources/askthedata.json");
+                assertEquals(jsonData.exists(), true);
 
-        File image = new File("src/test/resources/dv_logo.png");
-        assertEquals(image.exists(), true);
+                File image = new File("src/test/resources/dv_logo.png");
+                assertEquals(image.exists(), true);
+                String contentType = adminHeaders.getContentType() != null ? adminHeaders.getContentType().toString() : "no val";
+                adminHeaders.setContentType(MediaType.MULTIPART_FORM_DATA);
+                MultiValueMap<String, Object> postNewToolBody = new LinkedMultiValueMap<>();
+                postNewToolBody.add("name", "AskTheData");
+                postNewToolBody.add("description",contentType);
+                postNewToolBody.add("dvMinVersion", "6.0");
+                postNewToolBody.add("releaseNote", "This release includes a new feature ...");
+                postNewToolBody.add("version", "1.0");
+                postNewToolBody.add("jsonData", new FileSystemResource(jsonData));
+                postNewToolBody.add("itemImages", new FileSystemResource(image));
 
-        adminHeaders.setContentType(MediaType.MULTIPART_FORM_DATA);
-        MultiValueMap<String, Object> postNewToolBody = new LinkedMultiValueMap<>();
-        postNewToolBody.add("name", "AskTheData");
-        postNewToolBody.add("description", "Ask the Data is an ...");
-        postNewToolBody.add("dvMinVersion", "6.0");
-        postNewToolBody.add("releaseNote", "This release includes a new feature ...");
-        postNewToolBody.add("version", "1.0");
-        postNewToolBody.add("jsonData", new FileSystemResource(jsonData));
-        postNewToolBody.add("itemImages", new FileSystemResource(image));
+                // admin does not have editor role, can not add a new tool
+                assertThrows(HttpClientErrorException.Unauthorized.class, () -> {
+                        restTemplate.postForEntity(serverUrl + "/tools",
+                                        new HttpEntity<>(postNewToolBody, adminHeaders),
+                                        ServerMessageResponse.class);
+                });
 
-        ResponseEntity<ExternalToolDTO> postToolResponse = restTemplate.postForEntity(serverUrl + "/tools",
-                new HttpEntity<>(postNewToolBody, adminHeaders), ExternalToolDTO.class);
-        assertEquals(postToolResponse.getStatusCode(), HttpStatus.OK);
+                // add the role and try again
+                TestUtils.assignRole(serverUrl, adminLogin, adminLogin.getId(), "EDITOR");
 
-        assertThrows(HttpClientErrorException.Unauthorized.class, () -> {
-            restTemplate.postForEntity(serverUrl + "/tools", new HttpEntity<>(postNewToolBody, userHeaders),
-                    ServerMessageResponse.class);
-        });
+                ResponseEntity<ExternalToolDTO> postToolResponse = restTemplate.postForEntity(serverUrl + "/tools",
+                                new HttpEntity<>(postNewToolBody, adminHeaders), ExternalToolDTO.class);
+                assertEquals(postToolResponse.getStatusCode(), HttpStatus.OK);
 
-        assertNotNull(postToolResponse.getBody());
-        String newToolPostUrl = toolsUrl + postToolResponse.getBody().getId();
+                // and remove the role
+                TestUtils.removeRole(serverUrl, adminLogin, adminLogin.getId(), "EDITOR");
 
-        // Get tool by ID test
-        ResponseEntity<ExternalToolDTO> getToolsByIdResponse 
-            = restTemplate.getForEntity(newToolPostUrl, ExternalToolDTO.class);
-        assertEquals(getToolsByIdResponse.getStatusCode(), HttpStatus.OK);
 
-        // Get Images test
-        String imagesUrl = newToolPostUrl + "/images";
-        ResponseEntity<MarketplaceItemImageDTO[]> getImagesResponse 
-            = restTemplate.getForEntity(imagesUrl,
-                MarketplaceItemImageDTO[].class);
-        assertEquals(getImagesResponse.getStatusCode(), HttpStatus.OK);
-        assertEquals(getImagesResponse.getBody().length, 1);
+                assertThrows(HttpClientErrorException.Unauthorized.class, () -> {
+                        restTemplate.postForEntity(serverUrl + "/tools", new HttpEntity<>(postNewToolBody, userHeaders),
+                                        ServerMessageResponse.class);
+                });
 
-        // Test get stored resource
-        ResponseEntity<byte[]> getStoredResourceResponse 
-            = restTemplate.getForEntity( serverUrl + "/stored-resource/" + getImagesResponse.getBody()[0].getStoredResourceId(), 
-            byte[].class);
-        assertEquals(getStoredResourceResponse.getStatusCode(), HttpStatus.OK);        
-        
-        // Test images post
-        adminHeaders.setContentType(MediaType.MULTIPART_FORM_DATA);
-        MultiValueMap<String, Object> imagePostBody = new LinkedMultiValueMap<>();
-        imagePostBody.add("images", new FileSystemResource(image));
+                assertNotNull(postToolResponse.getBody());
+                String newToolPostUrl = toolsUrl + postToolResponse.getBody().getId();
 
-        ResponseEntity<MarketplaceItemImageDTO[]> postImagesResponse 
-            = restTemplate.postForEntity(imagesUrl,
-                    new HttpEntity<>(imagePostBody, adminHeaders), 
-                    MarketplaceItemImageDTO[].class);
-        assertEquals(postImagesResponse.getStatusCode(), HttpStatus.OK);
+                // Get tool by ID test
+                ResponseEntity<ExternalToolDTO> getToolsByIdResponse = restTemplate.getForEntity(newToolPostUrl,
+                                ExternalToolDTO.class);
+                assertEquals(getToolsByIdResponse.getStatusCode(), HttpStatus.OK);
 
-        getImagesResponse = restTemplate.getForEntity( imagesUrl,
-                        MarketplaceItemImageDTO[].class);
-        assertEquals(getImagesResponse.getStatusCode(), HttpStatus.OK);
-        assertEquals(getImagesResponse.getBody().length, 2);
+                // Get Images test
+                String imagesUrl = newToolPostUrl + "/images";
+                ResponseEntity<MarketplaceItemImageDTO[]> getImagesResponse = restTemplate.getForEntity(imagesUrl,
+                                MarketplaceItemImageDTO[].class);
+                assertEquals(getImagesResponse.getStatusCode(), HttpStatus.OK);
+                assertEquals(getImagesResponse.getBody().length, 1);
 
-        // Test delete image
-        adminHeaders.setContentType(MediaType.APPLICATION_JSON);
-        ResponseEntity<ServerMessageResponse> deleteImageResponse 
-            = restTemplate.exchange( newToolPostUrl + "/images/" + getImagesResponse.getBody()[0].getStoredResourceId(),
-                        HttpMethod.DELETE, 
-                        new HttpEntity<>(adminHeaders),
-            ServerMessageResponse.class);
-        assertEquals(deleteImageResponse.getStatusCode(), HttpStatus.OK);
+                // Test get stored resource
+                ResponseEntity<byte[]> getStoredResourceResponse = restTemplate.getForEntity(
+                                serverUrl + "/stored-resource/" + getImagesResponse.getBody()[0].getStoredResourceId(),
+                                byte[].class);
+                assertEquals(getStoredResourceResponse.getStatusCode(), HttpStatus.OK);
 
-        getImagesResponse = restTemplate.getForEntity(
-                imagesUrl,
-                MarketplaceItemImageDTO[].class);
-        assertEquals(getImagesResponse.getStatusCode(), HttpStatus.OK);
-        assertEquals(getImagesResponse.getBody().length, 1);
+                // Test images post
+                adminHeaders.setContentType(MediaType.MULTIPART_FORM_DATA);
+                MultiValueMap<String, Object> imagePostBody = new LinkedMultiValueMap<>();
+                imagePostBody.add("images", new FileSystemResource(image));
 
-        // Test get version
-        ResponseEntity<ExternalToolVersionDTO[]> getVersionsResponse = restTemplate.getForEntity(
-                newToolPostUrl + "/versions",
-                ExternalToolVersionDTO[].class);
-        assertEquals(getVersionsResponse.getStatusCode(), HttpStatus.OK);
-        assertEquals(getVersionsResponse.getBody().length, 1);
+                ResponseEntity<MarketplaceItemImageDTO[]> postImagesResponse = restTemplate.postForEntity(imagesUrl,
+                                new HttpEntity<>(imagePostBody, adminHeaders),
+                                MarketplaceItemImageDTO[].class);
+                assertEquals(postImagesResponse.getStatusCode(), HttpStatus.OK);
 
-        // Test get version by ID
-        ResponseEntity<ExternalToolVersionDTO> getVersionByIdResponse = restTemplate.getForEntity(toolsUrl
-                + postToolResponse.getBody().getId() + "/versions/" + getVersionsResponse.getBody()[0].getId(),
-                ExternalToolVersionDTO.class);
-        assertEquals(getVersionByIdResponse.getStatusCode(), HttpStatus.OK);
-        assertEquals(getVersionsResponse.getBody()[0].toString(), getVersionByIdResponse.getBody().toString());
+                getImagesResponse = restTemplate.getForEntity(imagesUrl,
+                                MarketplaceItemImageDTO[].class);
+                assertEquals(getImagesResponse.getStatusCode(), HttpStatus.OK);
+                assertEquals(getImagesResponse.getBody().length, 2);
 
-        // Test post version
-        adminHeaders.setContentType(MediaType.MULTIPART_FORM_DATA);
-        MultiValueMap<String, Object> postVersionBody = new LinkedMultiValueMap<>();
-        postVersionBody.add("version", "1.1");
-        postVersionBody.add("jsonData", new FileSystemResource(jsonData));
-        postVersionBody.add("releaseNote",
-                "This release includes ...");
-        postVersionBody.add("dvMinVersion", "6.0");
+                // Test delete image
+                adminHeaders.setContentType(MediaType.APPLICATION_JSON);
+                ResponseEntity<ServerMessageResponse> deleteImageResponse = restTemplate.exchange(
+                                newToolPostUrl + "/images/" + getImagesResponse.getBody()[0].getStoredResourceId(),
+                                HttpMethod.DELETE,
+                                new HttpEntity<>(adminHeaders),
+                                ServerMessageResponse.class);
+                assertEquals(deleteImageResponse.getStatusCode(), HttpStatus.OK);
 
-        ResponseEntity<ExternalToolVersionDTO> postVersionResponse = restTemplate.postForEntity(
-                newToolPostUrl + "/versions",
-                new HttpEntity<>(postVersionBody, adminHeaders),
-                ExternalToolVersionDTO.class);
-        assertEquals(postVersionResponse.getStatusCode(), HttpStatus.OK);
+                getImagesResponse = restTemplate.getForEntity(
+                                imagesUrl,
+                                MarketplaceItemImageDTO[].class);
+                assertEquals(getImagesResponse.getStatusCode(), HttpStatus.OK);
+                assertEquals(getImagesResponse.getBody().length, 1);
 
-        getVersionsResponse = restTemplate.getForEntity(
-                newToolPostUrl + "/versions",
-                ExternalToolVersionDTO[].class);
-        assertEquals(getVersionsResponse.getStatusCode(), HttpStatus.OK);
-        assertEquals(getVersionsResponse.getBody().length, 2);
+                // Test get version
+                ResponseEntity<ExternalToolVersionDTO[]> getVersionsResponse = restTemplate.getForEntity(
+                                newToolPostUrl + "/versions",
+                                ExternalToolVersionDTO[].class);
+                assertEquals(getVersionsResponse.getStatusCode(), HttpStatus.OK);
+                assertEquals(getVersionsResponse.getBody().length, 1);
 
-        // Test put version
-        final String UPDATED = "UPDATED";
-        Map<String, String> putVersionBody = new HashMap<String, String>();
-        putVersionBody.put("version", UPDATED);
-        putVersionBody.put("releaseNote", UPDATED);
-        putVersionBody.put("dvMinVersion", UPDATED);
+                // Test get version by ID
+                ResponseEntity<ExternalToolVersionDTO> getVersionByIdResponse = restTemplate.getForEntity(toolsUrl
+                                + postToolResponse.getBody().getId() + "/versions/"
+                                + getVersionsResponse.getBody()[0].getId(),
+                                ExternalToolVersionDTO.class);
+                assertEquals(getVersionByIdResponse.getStatusCode(), HttpStatus.OK);
+                assertEquals(getVersionsResponse.getBody()[0].toString(), getVersionByIdResponse.getBody().toString());
 
-        adminHeaders.setContentType(MediaType.APPLICATION_JSON);
+                // Test post version
+                adminHeaders.setContentType(MediaType.MULTIPART_FORM_DATA);
+                MultiValueMap<String, Object> postVersionBody = new LinkedMultiValueMap<>();
+                postVersionBody.add("version", "1.1");
+                postVersionBody.add("jsonData", new FileSystemResource(jsonData));
+                postVersionBody.add("releaseNote",
+                                "This release includes ...");
+                postVersionBody.add("dvMinVersion", "6.0");
 
-        ResponseEntity<ExternalToolVersionDTO> putVersionResponse = restTemplate.exchange(
-                newToolPostUrl +
-                        "/versions/" + postVersionResponse.getBody().getId(),
-                HttpMethod.PUT,
-                new HttpEntity<>(putVersionBody, adminHeaders),
-                ExternalToolVersionDTO.class);
+                ResponseEntity<ExternalToolVersionDTO> postVersionResponse = restTemplate.postForEntity(
+                                newToolPostUrl + "/versions",
+                                new HttpEntity<>(postVersionBody, adminHeaders),
+                                ExternalToolVersionDTO.class);
+                assertEquals(postVersionResponse.getStatusCode(), HttpStatus.OK);
 
-        assertEquals(putVersionResponse.getStatusCode(), HttpStatus.OK);
+                getVersionsResponse = restTemplate.getForEntity(
+                                newToolPostUrl + "/versions",
+                                ExternalToolVersionDTO[].class);
+                assertEquals(getVersionsResponse.getStatusCode(), HttpStatus.OK);
+                assertEquals(getVersionsResponse.getBody().length, 2);
 
-        getVersionsResponse = restTemplate.getForEntity(
-                newToolPostUrl + "/versions",
-                ExternalToolVersionDTO[].class);
-        assertEquals(getVersionsResponse.getStatusCode(), HttpStatus.OK);
-        assertEquals(getVersionsResponse.getBody().length, 2);
-        assertEquals(getVersionsResponse.getBody()[1].getReleaseNote(), UPDATED);
-        assertEquals(getVersionsResponse.getBody()[1].getVersion(), UPDATED);
-        assertEquals(getVersionsResponse.getBody()[1].getDataverseMinVersion(), UPDATED);
+                // Test put version
+                final String UPDATED = "UPDATED";
+                Map<String, String> putVersionBody = new HashMap<String, String>();
+                putVersionBody.put("version", UPDATED);
+                putVersionBody.put("releaseNote", UPDATED);
+                putVersionBody.put("dvMinVersion", UPDATED);
 
-        // Test get manifest
-        ResponseEntity<ExternalToolManifestDTO[]> getManifestResponse = restTemplate.getForEntity(
-                newToolPostUrl
-                        + "/versions/" + getVersionsResponse.getBody()[0].getId() + "/manifests",
-                ExternalToolManifestDTO[].class);
+                adminHeaders.setContentType(MediaType.APPLICATION_JSON);
 
-        assertEquals(getManifestResponse.getStatusCode(), HttpStatus.OK);
-        assertEquals(getManifestResponse.getBody().length, 1);
+                ResponseEntity<ExternalToolVersionDTO> putVersionResponse = restTemplate.exchange(
+                                newToolPostUrl +
+                                                "/versions/" + postVersionResponse.getBody().getId(),
+                                HttpMethod.PUT,
+                                new HttpEntity<>(putVersionBody, adminHeaders),
+                                ExternalToolVersionDTO.class);
 
-        // Test post manifest
-        File manifest = new File("src/test/resources/askthedata.json");
-        assertEquals(manifest.exists(), true);
+                assertEquals(putVersionResponse.getStatusCode(), HttpStatus.OK);
 
-        adminHeaders.setContentType(MediaType.MULTIPART_FORM_DATA);
-        MultiValueMap<String, Object> postManifestBody = new LinkedMultiValueMap<>();
-        postManifestBody.add("jsonData", new FileSystemResource(manifest));
+                getVersionsResponse = restTemplate.getForEntity(
+                                newToolPostUrl + "/versions",
+                                ExternalToolVersionDTO[].class);
+                assertEquals(getVersionsResponse.getStatusCode(), HttpStatus.OK);
+                assertEquals(getVersionsResponse.getBody().length, 2);
+                assertEquals(getVersionsResponse.getBody()[1].getReleaseNote(), UPDATED);
+                assertEquals(getVersionsResponse.getBody()[1].getVersion(), UPDATED);
+                assertEquals(getVersionsResponse.getBody()[1].getDataverseMinVersion(), UPDATED);
 
-        ResponseEntity<ExternalToolManifestDTO[]> postManifestResponse = restTemplate.postForEntity(
-                newToolPostUrl + "/versions/"
-                        + getVersionsResponse.getBody()[0].getId() + "/manifests",
-                new HttpEntity<>(postManifestBody, adminHeaders), ExternalToolManifestDTO[].class);
-        assertEquals(postManifestResponse.getStatusCode(), HttpStatus.OK);
+                // Test get manifest
+                ResponseEntity<ExternalToolManifestDTO[]> getManifestResponse = restTemplate.getForEntity(
+                                newToolPostUrl
+                                                + "/versions/" + getVersionsResponse.getBody()[0].getId()
+                                                + "/manifests",
+                                ExternalToolManifestDTO[].class);
 
-        getManifestResponse = restTemplate.getForEntity(
-                newToolPostUrl + "/versions/"
-                        + getVersionsResponse.getBody()[0].getId() + "/manifests",
-                ExternalToolManifestDTO[].class);
+                assertEquals(getManifestResponse.getStatusCode(), HttpStatus.OK);
+                assertEquals(getManifestResponse.getBody().length, 1);
 
-        assertEquals(getManifestResponse.getStatusCode(), HttpStatus.OK);
-        assertEquals(getManifestResponse.getBody().length, 2);
+                // Test post manifest
+                File manifest = new File("src/test/resources/askthedata.json");
+                assertEquals(manifest.exists(), true);
 
-        // Test delete manifest
-        adminHeaders.setContentType(MediaType.APPLICATION_JSON);
-        ResponseEntity<ServerMessageResponse> deleteManifestResponse = restTemplate.exchange(
-                newToolPostUrl + "/versions/"
-                        + getVersionsResponse.getBody()[0].getId() + "/manifests/"
-                        + getManifestResponse.getBody()[0].getManifestId(),
-                org.springframework.http.HttpMethod.DELETE, new HttpEntity<>(adminHeaders),
-                ServerMessageResponse.class);
+                adminHeaders.setContentType(MediaType.MULTIPART_FORM_DATA);
+                MultiValueMap<String, Object> postManifestBody = new LinkedMultiValueMap<>();
+                postManifestBody.add("jsonData", new FileSystemResource(manifest));
 
-        assertEquals(deleteManifestResponse.getStatusCode(), HttpStatus.OK);
+                ResponseEntity<ExternalToolManifestDTO[]> postManifestResponse = restTemplate.postForEntity(
+                                newToolPostUrl + "/versions/"
+                                                + getVersionsResponse.getBody()[0].getId() + "/manifests",
+                                new HttpEntity<>(postManifestBody, adminHeaders), ExternalToolManifestDTO[].class);
+                assertEquals(postManifestResponse.getStatusCode(), HttpStatus.OK);
 
-        getManifestResponse = restTemplate.getForEntity(
-                newToolPostUrl + "/versions/"
-                        + getVersionsResponse.getBody()[0].getId() + "/manifests",
-                ExternalToolManifestDTO[].class);
+                getManifestResponse = restTemplate.getForEntity(
+                                newToolPostUrl + "/versions/"
+                                                + getVersionsResponse.getBody()[0].getId() + "/manifests",
+                                ExternalToolManifestDTO[].class);
 
-        assertEquals(getManifestResponse.getStatusCode(), HttpStatus.OK);
-        assertEquals(getManifestResponse.getBody().length, 1);
+                assertEquals(getManifestResponse.getStatusCode(), HttpStatus.OK);
+                assertEquals(getManifestResponse.getBody().length, 2);
 
-        // Test delete version
-        adminHeaders.setContentType(MediaType.APPLICATION_JSON);
-        ResponseEntity<ServerMessageResponse> deleteVersionResponse = restTemplate.exchange(
-                newToolPostUrl + "/versions/"
-                        + getVersionsResponse.getBody()[1].getId(),
-                org.springframework.http.HttpMethod.DELETE, new HttpEntity<>(adminHeaders),
-                ServerMessageResponse.class);
-        assertEquals(deleteVersionResponse.getStatusCode(), HttpStatus.OK);
+                // Test delete manifest
+                adminHeaders.setContentType(MediaType.APPLICATION_JSON);
+                ResponseEntity<ServerMessageResponse> deleteManifestResponse = restTemplate.exchange(
+                                newToolPostUrl + "/versions/"
+                                                + getVersionsResponse.getBody()[0].getId() + "/manifests/"
+                                                + getManifestResponse.getBody()[0].getManifestId(),
+                                org.springframework.http.HttpMethod.DELETE, new HttpEntity<>(adminHeaders),
+                                ServerMessageResponse.class);
 
-        getVersionsResponse = restTemplate.getForEntity(
-                newToolPostUrl + "/versions",
-                ExternalToolVersionDTO[].class);
-        assertEquals(getVersionsResponse.getStatusCode(), HttpStatus.OK);
-        assertEquals(getVersionsResponse.getBody().length, 1);
+                assertEquals(deleteManifestResponse.getStatusCode(), HttpStatus.OK);
 
-    }
+                getManifestResponse = restTemplate.getForEntity(
+                                newToolPostUrl + "/versions/"
+                                                + getVersionsResponse.getBody()[0].getId() + "/manifests",
+                                ExternalToolManifestDTO[].class);
+
+                assertEquals(getManifestResponse.getStatusCode(), HttpStatus.OK);
+                assertEquals(getManifestResponse.getBody().length, 1);
+
+                // Test delete version
+                adminHeaders.setContentType(MediaType.APPLICATION_JSON);
+                ResponseEntity<ServerMessageResponse> deleteVersionResponse = restTemplate.exchange(
+                                newToolPostUrl + "/versions/"
+                                                + getVersionsResponse.getBody()[1].getId(),
+                                org.springframework.http.HttpMethod.DELETE, new HttpEntity<>(adminHeaders),
+                                ServerMessageResponse.class);
+                assertEquals(deleteVersionResponse.getStatusCode(), HttpStatus.OK);
+
+                getVersionsResponse = restTemplate.getForEntity(
+                                newToolPostUrl + "/versions",
+                                ExternalToolVersionDTO[].class);
+                assertEquals(getVersionsResponse.getStatusCode(), HttpStatus.OK);
+                assertEquals(getVersionsResponse.getBody().length, 1);
+
+        }     
 
 }

--- a/src/test/java/org/dataverse/marketplace/TestUtils.java
+++ b/src/test/java/org/dataverse/marketplace/TestUtils.java
@@ -1,0 +1,65 @@
+package org.dataverse.marketplace;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.dataverse.marketplace.model.Role;
+import org.dataverse.marketplace.payload.ServerMessageResponse;
+import org.dataverse.marketplace.payload.auth.response.JwtResponse;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.RestTemplate;
+
+public class TestUtils {
+
+        private static RestTemplate restTemplate = new RestTemplate();
+
+        public static void assignRole (String serverUrl, JwtResponse adminLogin, Long userId, String roleName) {
+
+                HttpHeaders roleAssignmentHeaders = new HttpHeaders();
+                roleAssignmentHeaders.setBearerAuth(adminLogin.getAccessToken()); 
+                HttpEntity<String> adminRequest = new HttpEntity<>(roleAssignmentHeaders);
+
+                ResponseEntity<Role[]> systemRoles
+                        = restTemplate.exchange(serverUrl + "/auth/roles", HttpMethod.GET, adminRequest, Role[].class);
+            
+                List<Role> systemRoleList = Arrays.asList(systemRoles.getBody());
+                List<Role> roleToAssign = systemRoleList.stream()
+                                                .filter(role -> roleName.equals(role.getName()))
+                                                .collect(Collectors.toList());
+                
+                // TODO CHECK IF ROLE ALREADY ASSIGNED
+                String roleAssignmentRequest = serverUrl + 
+                                            "/auth/roles/" +  roleToAssign.get(0).getId() +
+                                            "/user/" + userId;  
+
+                restTemplate.postForEntity(roleAssignmentRequest, adminRequest, ServerMessageResponse.class);
+        }
+
+        public static void removeRole (String serverUrl, JwtResponse adminLogin, Long userId, String roleName) {
+
+                HttpHeaders roleAssignmentHeaders = new HttpHeaders();
+                roleAssignmentHeaders.setBearerAuth(adminLogin.getAccessToken()); 
+                HttpEntity<String> adminRequest = new HttpEntity<>(roleAssignmentHeaders);                
+
+                ResponseEntity<Role[]> systemRoles
+                        = restTemplate.exchange(serverUrl + "/auth/roles", HttpMethod.GET, adminRequest, Role[].class);
+            
+                List<Role> systemRoleList = Arrays.asList(systemRoles.getBody());
+                List<Role> roleToRemove = systemRoleList.stream()
+                                                .filter(role -> roleName.equals(role.getName()))
+                                                .collect(Collectors.toList());
+
+                // TODO CHECK IF ROLE IS ASSIGNED                                
+                String roleAssignmentRequest = serverUrl + 
+                                            "/auth/roles/" + roleToRemove.get(0).getId() +
+                                            "/user/" + userId;  
+
+                restTemplate.exchange(roleAssignmentRequest, 
+                        org.springframework.http.HttpMethod.DELETE, adminRequest, ServerMessageResponse.class);
+        }   
+
+}


### PR DESCRIPTION
- Added owner field to MarketplaceItem model.
- Updated ExternalToolService to handle tools by owner ID.
- Created new API endpoint to retrieve tools by owner ID.
- Modified addTool method to associate the tool with the authenticated user.
- Enhanced security roles to allow EDITOR role to manage their own tools.
- Updated UI components to include a checkbox for filtering tools by ownership.
- Added database migration script to add owner_id column to marketplace_item table.

For the reviewer:
• Do we like the role of EDITOR for someone who can create new items (tools) and have ownership over them?
• Right now, with the DTO having the user, the owner email is exposed? Is this OK? (generally exposing emails is bad, but in this case, we may want these to be available, as long as the uasers know?)
• There is an Ad Role API, do we need this (roles will need code changes, so I think this should just be an in code thing?_
• Current logic requires EDITOR role to add tools (ADMIN role is not enough, but user can easily be given more than one role). ADMIN is enough to edit, though. Do we like this approach?
• Current logic requires user to be owner and have EDITOR role to edit, in case we need to disable someone who owns a tool from future edits. Do we like this approach?

