### PR TITLE
update dependency version for springdoc-openapi and correct schema ty…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,13 +71,11 @@
 			</exclusions>
 		</dependency>
 
-		
-
 		<!-- Spring OPenAPI-->
 		<dependency>
 			<groupId>org.springdoc</groupId>
 			<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
-			<version>2.8.4</version>
+			<version>2.8.8</version>
 		</dependency>
 
 		<!-- PostgreSQL database -->

--- a/src/main/java/org/dataverse/marketplace/openapi/annotations/AuthAPIDocs.java
+++ b/src/main/java/org/dataverse/marketplace/openapi/annotations/AuthAPIDocs.java
@@ -117,12 +117,12 @@ public @interface AuthAPIDocs {
                 description = "The user id to assign the role to", 
                 required = true, 
                 in = ParameterIn.PATH, 
-                schema = @Schema(type = "long", format = "int64"))
+                schema = @Schema(type = "integer", format = "int64"))
     @Parameter(name = "roleId",
                 description = "The role id to assign to the user.",
                 required = true,
                 in = ParameterIn.PATH,
-                schema = @Schema(type = "long"))
+                schema = @Schema(type = "integer", format = "int64"))
     public @interface AssignRole{}
 
     @Target({ElementType.METHOD})    
@@ -156,12 +156,12 @@ public @interface AuthAPIDocs {
                 description = "The user id to remove the role from", 
                 required = true, 
                 in = ParameterIn.PATH, 
-                schema = @Schema(type = "long", format = "int64"))
+                schema = @Schema(type = "integer", format = "int64"))
     @Parameter(name = "roleId",
                 description = "The role id to be removed from the user",
                 required = true,
                 in = ParameterIn.PATH,
-                schema = @Schema(type = "long"))
+                schema = @Schema(type = "integer", format = "int64"))
     public @interface RemoveRole{}
 
     @Target({ElementType.METHOD})    
@@ -288,7 +288,7 @@ public @interface AuthAPIDocs {
                 description = "The id of the user to be retrieved",
                 required = true,
                 in = ParameterIn.PATH,
-                schema = @Schema(type = "long", format = "int64"))
+                schema = @Schema(type = "integer", format = "int64"))
     public @interface GetUser{}
 
 }

--- a/src/main/java/org/dataverse/marketplace/openapi/annotations/ExternalToolsAPIDocs.java
+++ b/src/main/java/org/dataverse/marketplace/openapi/annotations/ExternalToolsAPIDocs.java
@@ -65,7 +65,7 @@ public @interface ExternalToolsAPIDocs {
             @ApiResponse(responseCode = "500", description = "Internal Server Error during External Tool retrieval", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ServerMessageResponse.class), examples = @ExampleObject(GenericBusinessSamples.SERVER_MESSAGE_RESPONSE)))
     })
     @Operation(summary = "Retrieves the information from the specified external tool.", description = "This endpoint retrieves the information from the specified external tool by id.")
-    @Parameter(name = "toolId", description = "The id of the external tool to be retrieved", required = true, in = ParameterIn.PATH, schema = @Schema(type = "integer"))
+    @Parameter(name = "toolId", description = "The id of the external tool to be retrieved", required = true, in = ParameterIn.PATH, schema = @Schema(type = "integer", format = "int64"))
     public @interface GetExternalToolByIdDoc {
     }
 


### PR DESCRIPTION
This updates the version of the OpenAPI library and fixes a couple of types that made the document not being usable by swagger. 


https://swagger.io/docs/specification/v3_0/data-models/data-types/

Long numbers are 64 bit long integers on OpenAPI. 

